### PR TITLE
Workaround for handling HTTPS

### DIFF
--- a/lib/frenetic/connection.rb
+++ b/lib/frenetic/connection.rb
@@ -30,6 +30,9 @@ class Frenetic
     def process_config(raw_cfg)
       @config = {}.merge(raw_cfg.to_hash)
       @config[:url] = Addressable::URI.parse(raw_cfg[:url])
+      if @config[:url] && @config[:url].port.nil?
+        @config[:url].port = @config[:url].inferred_port
+      end
       cfgs = @config.inject({builder:{}, conn:{}}) do |conf, (k,v)|
         if ConnectionConfigKeys.include?(k)
           conf[:conn][k] = v

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -42,8 +42,20 @@ describe Frenetic::Connection do
       expect(subject[1]).to include :url
     end
 
-    it 'converts URLs to URIs' do
-      expect(subject[1]).to include url:kind_of(Addressable::URI)
+    context 'with specific port' do
+      let(:url) { 'https://example.com:8443' }
+      it 'converts URLs to URIs' do
+        expect(subject[1]).to include url:kind_of(Addressable::URI)
+        expect(subject[1][:url].port).to eq(8443)
+      end
+    end
+
+    context 'with no specific port' do
+      let(:url) { 'https://example.com' }
+      it 'converts URLs to URIs with port inferred from scheme' do
+        expect(subject[1]).to include url:kind_of(Addressable::URI)
+        expect(subject[1][:url].port).to eq(443)
+      end
     end
   end
 


### PR DESCRIPTION
According to lostisland/faraday#318, `Faraday::Adapter::NetHttp` cannot currently use HTTPS with `Addressable::URI` with no specific port. (We can use HTTPS with `https://example.com:443/`)
I thought that we should take care of this as a consumer of Faraday with Addressable.

This patch is workaround for that. 
